### PR TITLE
Send 204 instead of 200 when there is no response body

### DIFF
--- a/browser_handler.go
+++ b/browser_handler.go
@@ -194,14 +194,17 @@ func (hndlr *browserHandler) ServeHTTP(compliance ComplianceOptions, ctx context
 					handleErr(compliance, outputSel.LastErr, r, w)
 					return
 				}
-				if !outputSel.IsNil() && a.Output() != nil {
-					setResponseContentType(r.Header.Get("Accept"), compliance, w)
-					if err = sendActionOutput(compliance, w.Header().Get("Content-Type"), w, outputSel, a); err != nil {
-						handleErr(compliance, err, r, w)
-						return
+				if !outputSel.IsNil() {
+					if a.Output() != nil {
+						setResponseContentType(r.Header.Get("Accept"), compliance, w)
+						if err = sendActionOutput(compliance, w.Header().Get("Content-Type"), w, outputSel, a); err != nil {
+							handleErr(compliance, err, r, w)
+							return
+						}
 					}
 				} else {
-					err = outputSel.LastErr
+					// Successfully processed POST but nothing to return
+					w.WriteHeader(http.StatusNoContent)
 				}
 			} else {
 				// CRUD - Insert

--- a/form_test.go
+++ b/form_test.go
@@ -49,7 +49,7 @@ func TestForm(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		b := node.NewBrowser(m, formDummyNode(t))
 		x := m.Actions()["x"]
-		input, err := readInput(Strict, r, x)
+		input, err := readInput(Strict, r.Header.Get("Content-Type"), r, x)
 		chkErr(t, err)
 		resp := b.Root().Find("x").Action(input)
 		chkErr(t, resp.LastErr)

--- a/server.go
+++ b/server.go
@@ -106,7 +106,8 @@ func (srv *Server) determineCompliance(r *http.Request) ComplianceOptions {
 	}
 	contentType := r.Header.Get("Content-Type")
 	acceptType := r.Header.Get("Accept")
-	if contentType == YangDataJsonMimeType1 || contentType == YangDataXmlMimeType1 || acceptType == YangDataJsonMimeType2 || acceptType == YangDataXmlMimeType2 {
+
+	if contentType == YangDataJsonMimeType1 || contentType == YangDataJsonMimeType2 || contentType == YangDataXmlMimeType1 || contentType == YangDataXmlMimeType2 || acceptType == YangDataJsonMimeType1 || acceptType == YangDataJsonMimeType2 || acceptType == YangDataXmlMimeType1 || acceptType == YangDataXmlMimeType2 {
 		return Strict
 	}
 	if acceptType == TextStreamMimeType {

--- a/server_test.go
+++ b/server_test.go
@@ -64,12 +64,15 @@ func TestServer(t *testing.T) {
 	contentType := "application/json"
 
 	r, _ = client.Post(addr+"/restconf/operations/car:rotateTires", contentType, nil)
-	fc.AssertEqual(t, 200, r.StatusCode)
+	fc.AssertEqual(t, 204, r.StatusCode)
 
-	r, _ = client.Post(addr+"/restconf/data/car:rotateTires", YangDataJsonMimeType, nil)
+	r, _ = client.Post(addr+"/restconf/data/car:rotateTires", YangDataJsonMimeType2, nil)
 	fc.AssertEqual(t, 400, r.StatusCode)
 
 	r, _ = client.Post(addr+"/restconf/data/car:rotateTires", contentType, nil)
+	fc.AssertEqual(t, 204, r.StatusCode)
+
+	r, _ = client.Post(addr+"/restconf/operations/car:get-miles", YangDataJsonMimeType2, nil)
 	fc.AssertEqual(t, 200, r.StatusCode)
 
 	s.Close()

--- a/testdata/car.go
+++ b/testdata/car.go
@@ -10,6 +10,10 @@ import (
 	"github.com/freeconf/yang/val"
 )
 
+type Output struct {
+	Miles int64 `json:"miles"`
+}
+
 // ////////////////////////
 // C A R
 // Your application code.
@@ -224,6 +228,9 @@ func Manage(c *Car) node.Node {
 				c.rotateTires()
 			case "replaceTires":
 				c.replaceTires()
+			case "get-miles":
+				output := Output{Miles: 20000}
+				return nodeutil.ReflectChild(output), nil
 			}
 			return nil, nil
 		},

--- a/testdata/car.yang
+++ b/testdata/car.yang
@@ -19,6 +19,14 @@ module car {
         description "replace all tires";
     }
 
+    rpc get-miles {
+        output {
+            leaf miles {
+                type int64;
+            }
+        }
+    }
+
     grouping car {
         list tire {
             description "rubber circular part that makes contact with road";

--- a/testdata/gold/car.json
+++ b/testdata/gold/car.json
@@ -19,6 +19,14 @@ module car {
         description "replace all tires";
     }
 
+    rpc get-miles {
+        output {
+            leaf miles {
+                type int64;
+            }
+        }
+    }
+
     grouping car {
         list tire {
             description "rubber circular part that makes contact with road";

--- a/testdata/gold/car.yang
+++ b/testdata/gold/car.yang
@@ -19,6 +19,14 @@ module car {
         description "replace all tires";
     }
 
+    rpc get-miles {
+        output {
+            leaf miles {
+                type int64;
+            }
+        }
+    }
+
     grouping car {
         list tire {
             description "rubber circular part that makes contact with road";


### PR DESCRIPTION
Send 204 instead of 200 when there is no response body.
RFC 8572 required a 204 response code for the report-progress